### PR TITLE
fixing missing curly brackets at the end of main function and removing .env from staging.

### DIFF
--- a/morpheus.js
+++ b/morpheus.js
@@ -539,4 +539,5 @@ async function node() {
     }
   }
 
-  main()
+}
+main()


### PR DESCRIPTION
The current node in `morhpeus.js` doesn't work because of missing curly brackets at the end of the main function so I added it.
Also, I have removed .env and added .env_example because the dev or anyone who might fork the repo could forget that `.env` is being staged and expose his secrets accidentally which is not a revertable thing. 